### PR TITLE
fix(parser): handle colon in captured values

### DIFF
--- a/src/hurl-parser.ts
+++ b/src/hurl-parser.ts
@@ -125,10 +125,15 @@ export function parseHurlOutput(
 		} else if (isTimings && line.trim() !== "") {
 			// Remove the '* ' prefix if it exists
 			const cleanedLine = line.startsWith("* ") ? line.slice(2) : line;
-			const [key, value] = cleanedLine.split(":").map((s) => s.trim());
-			if (currentEntry && key && value) {
-				if (currentEntry.timings) {
-					currentEntry.timings[key] = value;
+			// Use the first ":" so values containing ":" remain intact
+			const separatorIndex = cleanedLine.indexOf(":");
+			if (separatorIndex !== -1) {
+				const key = cleanedLine.slice(0, separatorIndex).trim();
+				const value = cleanedLine.slice(separatorIndex + 1).trim();
+				if (currentEntry && key && value) {
+					if (currentEntry.timings) {
+						currentEntry.timings[key] = value;
+					}
 				}
 				// Check if this is the total timing, which marks the end of timing section
 				if (key === "total") {
@@ -147,9 +152,14 @@ export function parseHurlOutput(
 		} else if (isCaptures && line.trim() !== "") {
 			// Remove the '* ' prefix if it exists
 			const cleanedLine = line.startsWith("* ") ? line.slice(2) : line;
-			const [key, value] = cleanedLine.split(":").map((s) => s.trim());
-			if (currentEntry?.captures && key && value) {
-				currentEntry.captures[key] = value;
+			// Use the first ":" so values containing ":" remain intact
+			const separatorIndex = cleanedLine.indexOf(":");
+			if (separatorIndex !== -1) {
+				const key = cleanedLine.slice(0, separatorIndex).trim();
+				const value = cleanedLine.slice(separatorIndex + 1).trim();
+				if (currentEntry?.captures && key && value) {
+					currentEntry.captures[key] = value;
+				}
 			}
 		} else if (isCaptures && line.trim() === "") {
 			isCaptures = false;

--- a/src/hurl-parser.ts
+++ b/src/hurl-parser.ts
@@ -138,7 +138,7 @@ export function parseHurlOutput(
 				// Check if this is the total timing, which marks the end of timing section
 				if (key === "total") {
 					isTimings = false;
-					if (currentEntry.timings) {
+					if (currentEntry?.timings) {
 						currentEntry.timings = formatTimings(currentEntry.timings);
 					}
 				}

--- a/test/hurl-parser.test.ts
+++ b/test/hurl-parser.test.ts
@@ -85,4 +85,30 @@ describe("parseHurlOutput", () => {
 			name: "Example",
 		});
 	});
+	it("should not truncate capture values containing colons", () => {
+		const url =
+			"http://localhost:4566/s3-bucket/folder/2025/3/18/test-document.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&x-id=PutObject";
+		const stderr = `
+* ------------------------------------------------------------------------------
+* Executing entry 1
+* Request:
+* POST https://example.com/upload
+* Response:
+< HTTP/1.1 200 OK
+< Content-Type: application/json
+* Response body:
+{"url": "${url}"}
+* Captures:
+* url: ${url}
+* ------------------------------------------------------------------------------
+`;
+		const stdout = `{"url": "${url}"}`;
+
+		const result = parseHurlOutput(stderr, stdout);
+
+		expect(result.entries).toHaveLength(1);
+		expect(result.entries[0].captures).toEqual({
+			url,
+		});
+	});
 });


### PR DESCRIPTION
## WHAT
Issue: https://github.com/jellydn/vscode-hurl-runner/issues/218

## WHY
To be able to handle urls in captures

## HOW
By extending hurl output parsing logic

## Types of changes

<!-- Types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] Linter
- [x] Tests
- [ ] Review comments
- [ ] Security

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `parseHurlOutput` in `hurl-parser.ts` to correctly handle captured values containing colons, with a new test case added.
> 
>   - **Bug Fix**:
>     - In `parseHurlOutput` in `hurl-parser.ts`, modify logic to handle captured values containing colons without truncation.
>     - Use the first colon as a separator to preserve values with colons.
>   - **Tests**:
>     - Add test case in `hurl-parser.test.ts` to verify captured values with colons are parsed correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jellydn%2Fvscode-hurl-runner&utm_source=github&utm_medium=referral)<sup> for f21873405cc2adba1291d233c7b7df39c24be532. You can [customize](https://app.ellipsis.dev/jellydn/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of timing and capture lines to correctly handle values containing colons, ensuring information is not truncated.

- **Tests**
  - Added a test case to verify that capture values with colons are parsed in full without being cut off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->