### PR TITLE
fix: inline variables not being expanded in Hurl commands

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
 	"organizeImports": {
 		"enabled": true
 	},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,9 +43,8 @@ export async function executeHurl(
 	const args = [filePath, verboseFlag];
 
 	for (const [key, value] of Object.entries(variables)) {
-		// Wrap value in quotes if it contains spaces
-		const formattedValue = value.includes(" ") ? `"${value}"` : value;
-		args.push("--variable", `${key}=${formattedValue}`);
+		// Don't add quotes - spawn handles escaping properly
+		args.push("--variable", `${key}=${value}`);
 	}
 
 	if (envFile) {
@@ -128,9 +127,8 @@ export async function executeHurlWithContent(
 	const args = [fsPath, verboseFlag];
 
 	for (const [key, value] of Object.entries(variables)) {
-		// Wrap value in quotes if it contains spaces
-		const formattedValue = value.includes(" ") ? `"${value}"` : value;
-		args.push("--variable", `${key}=${formattedValue}`);
+		// Don't add quotes - spawn handles escaping properly
+		args.push("--variable", `${key}=${value}`);
 	}
 
 	if (envFile) {


### PR DESCRIPTION
## Summary
- Fixes issue where inline variables like `{{email}}` were not being expanded by Hurl
- Removes unnecessary quote wrapping when passing variables to the Hurl process

## Problem
When using inline variables in Hurl files, they were being passed as literal strings (e.g., `"user@example.com"`) instead of being properly expanded by Hurl. This was caused by the code adding quotes around variable values that contain spaces.

## Solution
Removed the quote wrapping logic because Node.js's `spawn` function already handles argument escaping properly. This allows Hurl to correctly interpret and expand variables.

## Testing
- Modified both `executeHurl` and `executeHurlWithContent` functions in `src/utils.ts`
- Verified that lint and typecheck pass successfully

Fixes #260

🤖 Generated with [Claude Code](https://claude.ai/code)