### PR TITLE
fix: comment highlighting after section blocks

### DIFF
--- a/syntaxes/hurl.tmLanguage.json
+++ b/syntaxes/hurl.tmLanguage.json
@@ -97,7 +97,7 @@
 		},
 		"query-params": {
 			"begin": "^\\[QueryStringParams\\]",
-			"end": "^(?=\\[|[A-Z])",
+			"end": "^(?=\\[|[A-Z]|#)",
 			"name": "meta.query-params.hurl",
 			"patterns": [
 				{
@@ -123,7 +123,7 @@
 		},
 		"form-params": {
 			"begin": "^\\[FormParams\\]",
-			"end": "^(?=\\[|[A-Z])",
+			"end": "^(?=\\[|[A-Z]|#)",
 			"name": "meta.form-params.hurl",
 			"patterns": [
 				{
@@ -149,7 +149,7 @@
 		},
 		"multipart-form-data": {
 			"begin": "^\\[MultipartFormData\\]",
-			"end": "^(?=\\[|[A-Z])",
+			"end": "^(?=\\[|[A-Z]|#)",
 			"name": "meta.multipart-form-data.hurl",
 			"patterns": [
 				{
@@ -181,7 +181,7 @@
 		},
 		"cookies": {
 			"begin": "^\\[Cookies\\]",
-			"end": "^(?=\\[|[A-Z])",
+			"end": "^(?=\\[|[A-Z]|#)",
 			"name": "meta.cookies.hurl",
 			"patterns": [
 				{
@@ -207,7 +207,7 @@
 		},
 		"basic-auth": {
 			"begin": "^\\[BasicAuth\\]",
-			"end": "^(?=\\[|[A-Z])",
+			"end": "^(?=\\[|[A-Z]|#)",
 			"name": "meta.basic-auth.hurl",
 			"patterns": [
 				{
@@ -233,7 +233,7 @@
 		},
 		"options": {
 			"begin": "^\\[Options\\]",
-			"end": "^(?=\\[|[A-Z])",
+			"end": "^(?=\\[|[A-Z]|#)",
 			"name": "meta.options.hurl",
 			"patterns": [
 				{
@@ -360,7 +360,7 @@
 		},
 		"captures": {
 			"begin": "^\\[Captures\\]",
-			"end": "^(?=\\[|[A-Z])",
+			"end": "^(?=\\[|[A-Z]|#)",
 			"name": "meta.captures.hurl",
 			"patterns": [
 				{
@@ -389,7 +389,7 @@
 		},
 		"asserts": {
 			"begin": "^\\[Asserts\\]",
-			"end": "^(?=\\[|[A-Z])",
+			"end": "^(?=\\[|[A-Z]|#)",
 			"name": "meta.asserts.hurl",
 			"patterns": [
 				{


### PR DESCRIPTION
## Summary

- Comments after `[Asserts]`, `[Captures]`, and other section blocks (`[QueryStringParams]`, `[FormParams]`, `[MultipartFormData]`, `[Cookies]`, `[BasicAuth]`, `[Options]`) were not syntax highlighted as comments
- The `end` pattern on these blocks (`^(?=\[|[A-Z])`) did not match lines starting with `#`, so the block never closed and swallowed the comment
- Adding `#` to the lookahead (`^(?=\[|[A-Z]|#)`) lets the block terminate before comment lines

## Before / After

Only the first comment in a `.hurl` file was highlighted. All subsequent comments between requests appeared as plain text.

**Before**

<img width="3008" height="1662" alt="CleanShot 2026-02-16 at 18 21 05@2x" src="https://github.com/user-attachments/assets/6312a6bf-fbae-4ee8-aea5-e8af443927f4" />


**After**

<img width="3008" height="1662" alt="CleanShot 2026-02-16 at 18 12 44@2x" src="https://github.com/user-attachments/assets/f385237c-e1ba-4233-86c0-ce637aa33992" />


## Test plan

- [ ] Open any `.hurl` file with multiple request entries separated by comments
- [ ] Verify all `# comment` lines are highlighted as comments, not just the first one